### PR TITLE
Fix Segfault on community

### DIFF
--- a/community/world.py
+++ b/community/world.py
@@ -149,6 +149,8 @@ class World:
 
 			self.entity_types[name] = entity_type.Entity_type(self, name, texture, model, width, height)
 
+		gl.glBindVertexArray(0)
+		
 		indices = []
 
 		for nquad in range(chunk.CHUNK_WIDTH * chunk.CHUNK_HEIGHT * chunk.CHUNK_LENGTH * 8):


### PR DESCRIPTION
Unbinds the last VAO so the global chunk Index Buffer doesn't get bound to it